### PR TITLE
Add validation for resize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ doujin-image-slimmer -i "original.zip" -o "slimmed.zip" --max-width 1600 --quali
 # GUIアプリからzipをドラッグ＆ドロップ → 設定を選んで「変換開始」ボタン
 ```
 
+## CLIアプリケーションの実行手順
+Rust をインストール後、`src-tauri` ディレクトリで次のコマンドを実行すると CLI 版を試せます。
+
+```sh
+cd src-tauri
+cargo run --bin zip-resizer-cli -- --help
+# 例: 入力 zip を変換して出力する
+cargo run --bin zip-resizer-cli -- -i input.zip -o output.zip --max-width 1600 --quality 80
+```
+
+
 ## 依存技術・主なクレート
 - image … 画像変換/圧縮
 - zip … zipファイル展開・再圧縮

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,12 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }
+zip = "0.6"
+rayon = "1"
+
+[[bin]]
+name = "zip-resizer-cli"
+path = "src/bin/cli.rs"
 

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+use clap::Parser;
+use zip_resizer_lib::{process_zip, ResizeOptions};
+
+/// Zip image resizer CLI
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Input zip file
+    #[arg(short, long)]
+    input: PathBuf,
+    /// Output zip file
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Maximum width of images
+    #[arg(long)]
+    max_width: Option<u32>,
+    /// Maximum height of images
+    #[arg(long)]
+    max_height: Option<u32>,
+    /// JPEG quality (1-100)
+    #[arg(long, default_value_t = 80)]
+    quality: u8,
+}
+
+fn main() {
+    let args = Args::parse();
+    let opts = match ResizeOptions::new(args.max_width, args.max_height, args.quality) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("Invalid options: {e}");
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = process_zip(&args.input, &args.output, &opts) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/src-tauri/src/core.rs
+++ b/src-tauri/src/core.rs
@@ -1,0 +1,112 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use image::{DynamicImage, ImageOutputFormat};
+use rayon::prelude::*;
+use zip::{ZipArchive, ZipWriter};
+use zip::write::FileOptions;
+
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug, Clone)]
+pub struct ResizeOptions {
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+    pub quality: u8,
+}
+
+impl Default for ResizeOptions {
+    fn default() -> Self {
+        Self { max_width: None, max_height: None, quality: 80 }
+    }
+}
+
+impl ResizeOptions {
+    pub fn new(
+        max_width: Option<u32>,
+        max_height: Option<u32>,
+        quality: u8,
+    ) -> Result<Self> {
+        if quality > 100 {
+            return Err(format!("quality must be between 0 and 100: {quality}").into());
+        }
+        Ok(Self { max_width, max_height, quality })
+    }
+}
+
+fn is_image(name: &str) -> bool {
+    matches!(Path::new(name).extension().and_then(|s| s.to_str()).map(|s| s.to_ascii_lowercase()).as_deref(),
+        Some("jpg") | Some("jpeg") | Some("png"))
+}
+
+fn resize_image(img: DynamicImage, opt: &ResizeOptions) -> DynamicImage {
+    let (mut w, mut h) = img.dimensions();
+    if let Some(max_w) = opt.max_width {
+        if w > max_w {
+            let ratio = max_w as f32 / w as f32;
+            w = max_w;
+            h = ((h as f32 * ratio) as u32).max(1);
+        }
+    }
+    if let Some(max_h) = opt.max_height {
+        if h > max_h {
+            let ratio = max_h as f32 / h as f32;
+            h = max_h;
+            w = ((w as f32 * ratio) as u32).max(1);
+        }
+    }
+    img.resize(w, h, image::imageops::FilterType::Lanczos3)
+}
+
+pub fn process_zip(input: &Path, output: &Path, opt: &ResizeOptions) -> Result<()> {
+    let input_file = File::open(input)?;
+    let mut archive = ZipArchive::new(input_file)?;
+
+    let mut entries = Vec::new();
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        if file.is_dir() { continue; }
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
+        entries.push((file.name().to_string(), data));
+    }
+
+    let processed: Vec<(String, Vec<u8>)> = entries
+        .into_par_iter()
+        .map(|(name, data)| {
+            if is_image(&name) {
+                match image::load_from_memory(&data) {
+                    Ok(img) => {
+                        let img = resize_image(img, opt);
+                        let mut buf = Vec::new();
+                        if let Err(e) = img.write_to(&mut buf, ImageOutputFormat::Jpeg(opt.quality)) {
+                            eprintln!("Failed to encode {name}: {e}");
+                            return (name, data);
+                        }
+                        (name, buf)
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to decode {name}: {e}");
+                        (name, data)
+                    }
+                }
+            } else {
+                (name, data)
+            }
+        })
+        .collect();
+
+    let output_file = File::create(output)?;
+    let mut writer = ZipWriter::new(output_file);
+    let options = FileOptions::default();
+
+    for (idx, (name, data)) in processed.into_iter().enumerate() {
+        println!("Processing {}", name);
+        writer.start_file(name, options)?;
+        writer.write_all(&data)?;
+    }
+
+    writer.finish()?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,7 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+pub mod core;
+pub use core::{process_zip, ResizeOptions};
+
+// Sample Tauri command. Keep for GUI testing.
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)


### PR DESCRIPTION
## Summary
- validate ResizeOptions quality range
- construct options in CLI with error handling
- document how to run the CLI application

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684f7633279c832cb53bc6263a8550ef