### PR TITLE
Add resize options to GUI

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,24 @@
 pub mod core;
 pub use core::{process_zip, ResizeOptions};
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GuiOptions {
+    max_width: Option<u32>,
+    max_height: Option<u32>,
+    quality: Option<u8>,
+}
+
+fn build_options(opt: Option<GuiOptions>) -> Result<ResizeOptions, String> {
+    match opt {
+        Some(o) => {
+            let q = o.quality.unwrap_or(80);
+            ResizeOptions::new(o.max_width, o.max_height, q).map_err(|e| e.to_string())
+        }
+        None => Ok(ResizeOptions::default()),
+    }
+}
+
 // Sample Tauri command. Keep for GUI testing.
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -8,7 +26,8 @@ fn greet(name: &str) -> String {
 }
 
 #[tauri::command]
-async fn process_zips(paths: Vec<String>) -> Result<(), String> {
+async fn process_zips(paths: Vec<String>, options: Option<GuiOptions>) -> Result<(), String> {
+    let opts = build_options(options)?;
     tauri::async_runtime::spawn_blocking(move || {
         for p in paths {
             let input = std::path::PathBuf::from(&p);
@@ -18,7 +37,7 @@ async fn process_zips(paths: Vec<String>) -> Result<(), String> {
                 .unwrap_or_else(|| "output".into());
             let output = input.with_file_name(format!("{out_name}_resized.zip"));
 
-            if let Err(e) = process_zip(&input, &output, &ResizeOptions::default()) {
+            if let Err(e) = process_zip(&input, &output, &opts) {
                 return Err(e.to_string());
             }
         }
@@ -29,7 +48,8 @@ async fn process_zips(paths: Vec<String>) -> Result<(), String> {
 }
 
 #[tauri::command]
-async fn process_zip_cmd(path: String) -> Result<(), String> {
+async fn process_zip_cmd(path: String, options: Option<GuiOptions>) -> Result<(), String> {
+    let opts = build_options(options)?;
     tauri::async_runtime::spawn_blocking(move || {
         let input = std::path::PathBuf::from(&path);
         let out_name = input
@@ -37,7 +57,7 @@ async fn process_zip_cmd(path: String) -> Result<(), String> {
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_else(|| "output".into());
         let output = input.with_file_name(format!("{out_name}_resized.zip"));
-        process_zip(&input, &output, &ResizeOptions::default()).map_err(|e| e.to_string())
+        process_zip(&input, &output, &opts).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,11 @@
       </form>
       <p id="greet-msg"></p>
       <button id="select-btn">Select ZIP Files</button>
+      <div id="options">
+        <label>Max Width: <input id="max-width" type="number" min="1" placeholder="None" /></label>
+        <label>Max Height: <input id="max-height" type="number" min="1" placeholder="None" /></label>
+        <label>Quality: <input id="quality" type="number" min="1" max="100" value="80" /></label>
+      </div>
       <ul id="file-list"></ul>
       <button id="process-btn">Start Processing</button>
     </main>

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,9 @@ let greetMsgEl;
 let fileListEl;
 let selectBtnEl;
 let processBtnEl;
+let maxWidthEl;
+let maxHeightEl;
+let qualityEl;
 const jobs = [];
 let processing = false;
 
@@ -20,6 +23,9 @@ window.addEventListener("DOMContentLoaded", () => {
   fileListEl = document.querySelector("#file-list");
   selectBtnEl = document.querySelector("#select-btn");
   processBtnEl = document.querySelector("#process-btn");
+  maxWidthEl = document.querySelector("#max-width");
+  maxHeightEl = document.querySelector("#max-height");
+  qualityEl = document.querySelector("#quality");
   document.querySelector("#greet-form").addEventListener("submit", (e) => {
     e.preventDefault();
     greet();
@@ -57,12 +63,21 @@ async function selectFiles() {
 async function processFiles() {
   if (processing || jobs.length === 0) return;
   processing = true;
+  const parseNumber = (el) => {
+    const v = parseInt(el.value, 10);
+    return Number.isNaN(v) ? null : v;
+  };
+  const opts = {
+    maxWidth: parseNumber(maxWidthEl),
+    maxHeight: parseNumber(maxHeightEl),
+    quality: parseNumber(qualityEl),
+  };
   await Promise.all(
     jobs.map(async (job) => {
       job.statusEl.textContent = "processing";
       job.statusEl.className = "status processing";
       try {
-        await invoke("process_zip_cmd", { path: job.path });
+        await invoke("process_zip_cmd", { path: job.path, options: opts });
         job.statusEl.textContent = "done";
         job.statusEl.className = "status done";
       } catch (e) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,6 +91,16 @@ button {
   margin-right: 5px;
 }
 
+#options {
+  margin-top: 10px;
+}
+#options label {
+  margin-right: 10px;
+}
+#options input {
+  width: 80px;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f6f6f6;


### PR DESCRIPTION
## Summary
- allow users to specify resize options from the GUI
- wire the new options into Tauri backend

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684f9498f83c832cab2fed1cc30865be